### PR TITLE
Fix multiple extend example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After installing, add this config to your stylelint config like so:
 }
 ```
 
-If you're extending multiple shareable configs, put this config as the last so it overrides all the previous configs when it comes to the rules relevant to Styled Components like so:
+If you're extending multiple shareable configs, put this config as the last so it overrides the relevant rules in all previous configs:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -31,14 +31,13 @@ After installing, add this config to your stylelint config like so:
 }
 ```
 
-If you're extending multiple shareable configs, put this config as the first so it overrides all
-following rules like so:
+If you're extending multiple shareable configs, put this config as the last so it overrides all the previous configs when it comes to the rules relevant to Styled Components like so:
 
 ```
 {
   "extends": [
-    "stylelint-config-styled-components-processor"
     "stylelint-config-standard",
+    "stylelint-config-styled-components-processor"
   ]
 }
 ```


### PR DESCRIPTION
From https://stylelint.io/user-guide/configuration/#extends :
> You can extend an array of existing configurations, with each item in the array taking precedence over the previous item (so the second item overrides rules in the first, the third item overrides rules in the first and the second, and so on, the last item overrides everything else).

I'm correct in fixing this right? This is what you meant isn't it?

I feel like my wording where I changed the wording in the README could be a bit smoother... If you have any suggestions feel free. Also if I misunderstood this, sorry :).