### PR TITLE
Add note to submit issues at processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The shareable stylelint config for [stylelint-processor-styled-components](https
 [![build status][build-badge]][build-url]
 [![greenkeeper badge][greenkeeper-badge]][greenkeeper-url]
 
+**If you're having problems with stylelint and styled-components, please submit an issue over at the [stylelint processor](https://github.com/styled-components/stylelint-processor-styled-components)!**
+
 ## Why
 
 When using [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components)


### PR DESCRIPTION
This is to avoid folks reporting issues like #19 here instead of in the processor.

Should we disable issues for this repo? I feel like most issues will be with the processor anyway, and we can always have discussions about the config over there too. @ismay @emilgoldsmith