### PR TITLE
Fix `no-empty-source` test case

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -38,7 +38,7 @@ describe('stylelint-config-styled-components', () => {
   })
 
   it('disables no-empty-source', () => {
-    const css = '\n'
+    const css = ''
     expect.assertions(1)
 
     return stylelint


### PR DESCRIPTION
Fixed #21.

Due to stylelint@9.6.0 changed behaves of `no-empty-source`, https://github.com/stylelint/stylelint/pull/3530, now `\n` is treated as 2 empty lines.