### PR TITLE
Fix stylelint rules conflicting with the styled-components processor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ module.exports = {
     "value-no-vendor-prefix": true,
     "property-no-vendor-prefix": true,
     "no-empty-source": null,
-    "no-missing-end-of-source-newline": null
+    "no-missing-end-of-source-newline": null,
+    // These selectors are used as placeholders by
+    // styled-components preprocessor
+    "selector-type-no-unknown": [true, { ignoreTypes: ["$dummyValue", "/^-styled-/"] }],
+    "selector-type-case": ["lower", { ignoreTypes: ["$dummyValue"] }]
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -74,4 +74,23 @@ describe('stylelint-config-styled-components', () => {
         expect(result.errored).toBe(false)
       })
   })
+
+  it('allows unknown placeholder from styled-components processor', () => {
+    const css = '-styled-mixin0 { color: blue; }\n$dummyValue { color: blue; }';
+    expect.assertions(1)
+
+    return stylelint
+      .lint({
+        code: css,
+        config: {
+          extends: [
+            'stylelint-config-standard',
+            './index'
+          ]
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(false)
+      })
+  })
 })


### PR DESCRIPTION
When using `stylelint-processor-styled-components`, stylelint default config complain about a few placeholder the processor use. I felt it'd be quite convenient to have those handled out of the box by the base configuration.