### PR TITLE
Remove deprecated rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ module.exports = {
   "rules": {
     "value-no-vendor-prefix": true,
     "property-no-vendor-prefix": true,
-    "no-empty-source": null,
-    "no-missing-end-of-source-newline": null
+    "no-empty-source": null
   }
 }


### PR DESCRIPTION
The line removed in this PR was deprecated in Stylelint 15 per https://github.com/stylelint/stylelint/blob/bc9225e53b2d937f1347d55766090cc6264e81a8/docs/migration-guide/to-15.md?plain=1#L66 and started erroring out for us as a missing rule in Stylelint 16.